### PR TITLE
Fix totalWeight not being reset in Clear

### DIFF
--- a/src/NRandom/Collections/WeightedList.cs
+++ b/src/NRandom/Collections/WeightedList.cs
@@ -107,6 +107,7 @@ public class WeightedList<T> : IReadOnlyWeightedList<T>, IList<WeightedValue<T>>
     public void Clear()
     {
         list.Clear();
+        totalWeight = 0.0;
     }
 
     public bool Contains(WeightedValue<T> item)


### PR DESCRIPTION
After calling Clear(), adding elements would result in incorrect probability calculations.